### PR TITLE
Add referral tracking and address parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ A TypeScript/Node.js CLI tool that fetches **all** NFT-minting traces and prize 
   - `isWin` — `true` if the trace includes a prize transfer
   - `winComment` — TON transfer comment (e.g. `x3`, `Jackpot winner`)
   - `winAmount` — prize in USDT equivalent (e.g. `700`)
+  - `winTonAmount` — actual TON amount transferred for the prize
+  - `referralAmount` — referral payout in TON if present
+  - `referralAddress` — wallet that received the referral payout
 
 - **Prize logic**: prizes are detected by comments in `ton_transfer` actions, matched via:
 
@@ -103,7 +106,9 @@ yarn start
 | isWin             | Boolean — `true` if a prize was transferred                 |
 | winComment        | Comment tag on `ton_transfer`, e.g. `x77`, `Jackpot winner` |
 | winAmount         | Parsed prize value in USDT or equivalent                    |
-
+| winTonAmount      | Actual TON amount transferred for the prize |
+| referralAmount    | Referral payout amount in TON |
+| referralAddress   | Wallet that received the referral payout |
 ---
 
 ## Developer Notes

--- a/src/services/tonApiService.ts
+++ b/src/services/tonApiService.ts
@@ -2,7 +2,18 @@ import axios from "axios";
 import { Buffer } from "buffer";
 import { CONFIG } from "../config/config.js";
 import { RawTrace, LotteryTx } from "../types/index.js";
-import { Address } from "@ton/core";
+import { Address, Cell } from "@ton/core";
+
+const PRIZE_MAP: Record<string, number> = {
+  x1: 10,
+  x3: 25,
+  x7: 50,
+  x20: 180,
+  x77: 700,
+  x200: 1800,
+  jp: 10000,
+  "Jackpot winner": 10000,
+};
 
 export class TonApiService {
   private client = axios.create({
@@ -51,35 +62,46 @@ export class TonApiService {
 
     const txHash = this.b64ToHex(rootB64);
 
-    const PRIZE_MAP: Record<string, number> = {
-      x1: 10,
-      x3: 25,
-      x7: 50,
-      x20: 180,
-      x77: 700,
-      x200: 1800,
-      jp: 10000,
-      "Jackpot winner": 10000,
-    };
 
     let winComment: string | null = null;
     let winAmount = 0;
+    let winTonAmount = 0;
+    let referralAmount = 0;
+    let referralAddress: string | null = null;
 
     for (const action of trace.actions) {
+      if (action.type !== "ton_transfer") continue;
+
       const comment = action.details?.comment;
-      if (action.type === "ton_transfer" && comment && PRIZE_MAP[comment]) {
+      const value = Number(action.details?.value) || 0;
+      const ton = value / 1e9;
+
+      if (comment && PRIZE_MAP[comment]) {
         winAmount = PRIZE_MAP[comment];
         winComment = comment;
-        console.log(`[API] 🎉 Win detected: ${comment} → ${winAmount} USDT`);
+        winTonAmount += ton;
+        console.log(`[API] 🎉 Win detected: ${comment} → ${winAmount} USDT, ${ton} TON`);
+      } else if (comment === "referral") {
+        referralAmount += ton;
+        console.log(`[API] 🤝 Referral detected: ${ton} TON`);
       }
     }
 
     const mint = trace.actions.find((a) => a.type === "nft_mint");
     const firstTx = trace.transactions_order?.[0];
-    const rawSource = firstTx
-      ? trace.transactions[firstTx]?.in_msg?.source ??
-        trace.transactions[firstTx]?.account
-      : null;
+    const firstIn = firstTx ? trace.transactions[firstTx]?.in_msg : null;
+    const rawSource = firstIn?.source ?? trace.transactions[firstTx || ""]?.account ?? null;
+
+    if (firstIn?.message_content?.body) {
+      try {
+        const cell = Cell.fromBase64(firstIn.message_content.body);
+        const slice = cell.beginParse();
+        const addr = slice.loadAddress();
+        referralAddress = addr.toString({ bounceable: false, urlSafe: true, testOnly: true });
+      } catch {
+        console.warn(`[API] ⚠ Failed to parse referral address in tx ${txHash}`);
+      }
+    }
 
     if (!rawSource) {
       console.warn(`[API] ⚠ Missing source in tx ${txHash}`);
@@ -134,6 +156,9 @@ export class TonApiService {
         isWin: winAmount > 0,
         winComment,
         winAmount,
+        winTonAmount: winTonAmount || null,
+        referralAmount: referralAmount || null,
+        referralAddress,
       };
     }
 
@@ -151,6 +176,9 @@ export class TonApiService {
         isWin: true,
         winComment,
         winAmount,
+        winTonAmount: winTonAmount || null,
+        referralAmount: referralAmount || null,
+        referralAddress,
       };
     }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,6 +34,12 @@ export interface InMsg {
   hash: string;
   source: string | null; // Can be null for external messages
   destination: string;
+  /** Raw TON cell body encoded as base64 */
+  message_content?: {
+    hash: string;
+    body: string;
+    decoded: any | null;
+  } | null;
   // ... other InMsg fields
 }
 
@@ -86,4 +92,10 @@ export interface LotteryTx {
   isWin: boolean;
   winComment: string | null;
   winAmount: number;
+  /** Actual TON amount transferred for the prize, if any (in TON) */
+  winTonAmount: number | null;
+  /** Referral payout amount in TON if present */
+  referralAmount: number | null;
+  /** Address that received the referral payout in friendly format */
+  referralAddress: string | null;
 }


### PR DESCRIPTION
## Summary
- record referral address from transaction payloads
- expose referral address and amounts in CSV and types
- document new field in README
- improve trace parsing logic and move prize map constant

## Testing
- `npm run build` *(fails: Cannot find module 'dotenv', missing dependencies)*